### PR TITLE
make order of headers deterministic

### DIFF
--- a/curlify.py
+++ b/curlify.py
@@ -3,7 +3,7 @@
 
 def to_curl(request):
     headers = ["'{0}: {1}'".format(k, v) for k, v in request.headers.items()]
-    headers = " -H ".join(headers)
+    headers = " -H ".join(sorted(headers))
 
     command = "curl -X {method} -H {headers} -d '{data}' '{uri}'".format(
         data=request.body or "",

--- a/curlify_test.py
+++ b/curlify_test.py
@@ -3,11 +3,22 @@
 import curlify
 import requests
 
+
 def test_ok():
-    r = requests.get("http://google.ru", data={"a": "b"}, cookies={"foo": "bar"}, headers={"user-agent": "mytest"})
+    r = requests.get(
+        "http://google.ru",
+        data={"a": "b"},
+        cookies={"foo": "bar"},
+        headers={"user-agent": "mytest"},
+    )
     assert curlify.to_curl(r.request) == (
-        "curl -X GET -H 'Content-Length: 3' -H 'Accept-Encoding: gzip, deflate' "
-        "-H 'Accept: */*' -H 'user-agent: mytest' -H 'Connection: keep-alive' "
-        "-H 'Cookie: foo=bar' -H 'Content-Type: application/x-www-form-urlencoded' "
+        "curl -X GET "
+        "-H 'Accept-Encoding: gzip, deflate' "
+        "-H 'Accept: */*' "
+        "-H 'Connection: keep-alive' "
+        "-H 'Content-Length: 3' "
+        "-H 'Content-Type: application/x-www-form-urlencoded' "
+        "-H 'Cookie: foo=bar' "
+        "-H 'user-agent: mytest' "
         "-d 'a=b' 'http://google.ru/'"
     )


### PR DESCRIPTION
Currently the test fails most of the time due to dict.items() having no determined ordering.

This change makes the list of headers appear in alphabetical order, so the output is always the same, for a given input.