### PR TITLE
include kwarg which accepts a string to separate `-H k: v` pairs

### DIFF
--- a/curlify.py
+++ b/curlify.py
@@ -7,7 +7,7 @@ else:
     from pipes import quote
 
 
-def to_curl(request, compressed=False, verify=True):
+def to_curl(request, compressed=False, verify=True, header_sep=None):
     """
     Returns string with curl command by provided request object
 
@@ -15,11 +15,16 @@ def to_curl(request, compressed=False, verify=True):
     ----------
     compressed : bool
         If `True` then `--compressed` argument will be added to result
+    header_sep : str
+        If not `None` then `header_sep` value will be added after each `'-H k: v'` pair
     """
     parts = [
         ('curl', None),
         ('-X', request.method),
     ]
+
+    if header_sep is None:
+        header_sep = ''
 
     for k, v in sorted(request.headers.items()):
         parts += [('-H', '{0}: {1}'.format(k, v))]
@@ -43,6 +48,8 @@ def to_curl(request, compressed=False, verify=True):
         if k:
             flat_parts.append(quote(k))
         if v:
-            flat_parts.append(quote(v))
-
+            temp_part = quote(v)
+            if k == "-H" and header_sep:
+                temp_part += header_sep
+            flat_parts.append(temp_part)
     return ' '.join(flat_parts)

--- a/curlify_test.py
+++ b/curlify_test.py
@@ -111,3 +111,17 @@ def test_post_csv_file():
     )
 
     assert curlified == expected
+
+
+def test_escapes_newlines():
+    r = requests.Request(
+        method='GET',
+        url='https://httpbin.org/get',
+        headers={
+            'User-Agent': 'UA',
+            'Accept': 'application/json'
+        }
+    )
+    curlified = curlify.to_curl(r.prepare(), header_sep='_')
+    expected = "curl -X GET -H 'Accept: application/json'_ -H 'User-Agent: UA'_ https://httpbin.org/get"
+    assert curlified == expected


### PR DESCRIPTION
main use case for this is for requests which have very long headers or a lot of them such that the curlified request, in its one-liner form, can be difficult to parse