### PR TITLE
feat: support custom http scheme

### DIFF
--- a/curlify.py
+++ b/curlify.py
@@ -1,5 +1,8 @@
 # coding: utf-8
 import sys
+from copy import deepcopy
+
+import requests
 
 if sys.version_info.major >= 3:
     from shlex import quote
@@ -46,3 +49,29 @@ def to_curl(request, compressed=False, verify=True):
             flat_parts.append(quote(v))
 
     return ' '.join(flat_parts)
+
+
+def to_raw_http_curl(response, *args, **kwargs):
+    """
+    Returns string with curl command by provided response object.
+
+    If you use a custom http scheme (like `http-custom://aaa.bbb.ccc/path`)
+    and use your custom `HTTPConnectionPool` to parse it to generate a http
+    connection, this method will return curl with the final http host.
+
+    Parameters
+    ----------
+    response : requests.models.Response
+    """
+    assert isinstance(response, requests.models.Response)
+    request = deepcopy(response.request)
+    connection_pool = response.connection.poolmanager.connection_from_url(request.url)
+    connection = connection_pool._get_conn()
+    http_scheme = connection_pool.scheme
+    if http_scheme not in ('http', 'https'):
+        http_scheme = 'http'
+
+    request.url = '{scheme}://{host}:{port}{path_url}'.format(
+        scheme=http_scheme, host=connection.host, port=connection.port, path_url=request.path_url
+    )
+    return to_curl(request, *args, **kwargs)


### PR DESCRIPTION
If you use a custom http scheme (like `http-custom://aaa.bbb.ccc/path`) and use your custom `HTTPConnectionPool` to parse it to generate a http connection, `to_curl` will give you inappropriate result:
```python3
resp = requests.get("http-custom://microservice.address/api/path")
curlify.to_curl(resp.request)  # curl -X GET http-custom://microservice.address/api/path
```

I created `to_raw_http_curl` to solve this kind of problem:
```python3
resp = requests.get("http-custom://microservice.address/api/path")
curlify.to_raw_http_curl(resp)  # curl -X GET http://11.22.33.44:80/api/path
```