### PR TITLE
Add skip_headers argument

### DIFF
--- a/curlify.py
+++ b/curlify.py
@@ -7,7 +7,7 @@ else:
     from pipes import quote
 
 
-def to_curl(request, compressed=False, verify=True):
+def to_curl(request, compressed=False, verify=True, skip_headers=False):
     """
     Returns string with curl command by provided request object
 
@@ -15,13 +15,20 @@ def to_curl(request, compressed=False, verify=True):
     ----------
     compressed : bool
         If `True` then `--compressed` argument will be added to result
+    verify: bool
+        If `True` then `--insecure` argument will be added to result
+    skip_headers: bool
+        If 'True' then headers [Accept, Accept-Encoding, Connection, User-Agent, Content-Length] will be skipped
     """
     parts = [
         ('curl', None),
         ('-X', request.method),
     ]
 
+    sys_headers = ['accept', 'accept-encoding', 'connection', 'user-agent', 'content-length']
     for k, v in sorted(request.headers.items()):
+        if skip_headers and k.lower() in sys_headers:
+            continue
         parts += [('-H', '{0}: {1}'.format(k, v))]
 
     if request.body:

--- a/curlify_test.py
+++ b/curlify_test.py
@@ -111,3 +111,17 @@ def test_post_csv_file():
     )
 
     assert curlified == expected
+
+
+def test_skip_headers():
+    r = requests.get(
+        "http://google.ru",
+        data={"a": "b"},
+        cookies={"foo": "bar"},
+    )
+    assert curlify.to_curl(r.request, skip_headers=True) == (
+        "curl -X GET "
+        "-H 'Content-Type: application/x-www-form-urlencoded' "
+        "-H 'Cookie: foo=bar' "
+        "-d a=b http://google.ru/"
+    )


### PR DESCRIPTION
By default returned string contains all headers including auto-generated ['accept', 'accept-encoding', 'connection', 'user-agent', 'content-length']. But these headers are not necessary to execute request by curl in terminal, and sometimes they can obstruct it execution. To avoid that case `skip_headers=True` can be passed to `to_curl` method. 