### PR TITLE
Add pyproject.toml file to align with PEP 518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute—see https://peps.python.org/pep-0518/#build-system-table.
+requires = ["setuptools", "wheel"]  # PEP 508 specifications.


### PR DESCRIPTION
Hi @ofw,

I added a minimal pyproject.toml file to align with PEP 518—see https://peps.python.org/pep-0518/#build-system-table.

I tested my change with the `pip install .` command—see shell session.

```
$ pip install .
# ...
  DEPRECATION: curlify is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559
  Running setup.py install for curlify ... done
Successfully installed certifi-2022.12.7 charset-normalizer-2.1.1 curlify-2.2.1 idna-3.4 requests-2.28.1 urllib3-1.26.13
$ cat <<TOML > pyproject.toml
[build-system]
# Minimum requirements for the build system to execute—see https://peps.python.org/pep-0518/#build-system-table.
requires = ["setuptools", "wheel"]  # PEP 508 specifications.
TOML
$ pip install .
# ...
Successfully installed curlify-2.2.1
```

Please let me know if I should bump the version in setup.py or do anything else.